### PR TITLE
country: fix countries import script (unknown type of subdivision)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+* Manage unknown subdivision type
+
 Version 6.0.0 - 2021-05-03
 * Bug fixes (see mercurial logs for details)
 * Rename zip into postal code

--- a/country.py
+++ b/country.py
@@ -197,7 +197,6 @@ class Subdivision(DeactivableMixin, ModelSQL, ModelView):
         ('unitary authority', 'Unitary authority'),
         ('unitary authority (england)', 'Unitary authority (england)'),
         ('unitary authority (wales)', 'Unitary authority (wales)'),
-        ('unknown', 'Unknown'),
         ('zone', 'zone'),
         ], 'Type', required=True)
     parent = fields.Many2One('country.subdivision', 'Parent',

--- a/country.py
+++ b/country.py
@@ -197,6 +197,7 @@ class Subdivision(DeactivableMixin, ModelSQL, ModelView):
         ('unitary authority', 'Unitary authority'),
         ('unitary authority (england)', 'Unitary authority (england)'),
         ('unitary authority (wales)', 'Unitary authority (wales)'),
+        ('unknown', 'Unknown'),
         ('zone', 'zone'),
         ], 'Type', required=True)
     parent = fields.Many2One('country.subdivision', 'Parent',

--- a/country.py
+++ b/country.py
@@ -94,6 +94,7 @@ class Subdivision(DeactivableMixin, ModelSQL, ModelView):
     code = fields.Char('Code', required=True, select=True,
         help="The ISO code of the subdivision.")
     type = fields.Selection([
+        (None, ""),
         ('administration', 'Administration'),
         ('administrative area', 'Administrative area'),
         ('administrative atoll', 'Administrative atoll'),
@@ -198,7 +199,7 @@ class Subdivision(DeactivableMixin, ModelSQL, ModelView):
         ('unitary authority (england)', 'Unitary authority (england)'),
         ('unitary authority (wales)', 'Unitary authority (wales)'),
         ('zone', 'zone'),
-        ], 'Type', required=True)
+        ], "Type")
     parent = fields.Many2One('country.subdivision', 'Parent',
         domain=[
             ('country', '=', Eval('country', -1)),
@@ -220,9 +221,14 @@ class Subdivision(DeactivableMixin, ModelSQL, ModelView):
 
         super().__register__(module_name)
 
+        table_h = cls.__table_handler__(module_name)
+
         # Migration from 5.2: remove country data
         cursor.execute(*data.delete(where=(data.module == 'country')
                 & (data.model == cls.__name__)))
+
+        # Migration from 6.2: remove type required
+        table_h.not_null_action('type', action='remove')
 
     @classmethod
     def search_rec_name(cls, name, clause):

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -535,9 +535,5 @@ msgid "Unitary authority (wales)"
 msgstr "Autorité unitaire (pays de galles)"
 
 msgctxt "selection:country.subdivision,type:"
-msgid "Unknown"
-msgstr "Inconnu"
-
-msgctxt "selection:country.subdivision,type:"
 msgid "zone"
 msgstr "Zone"

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -535,5 +535,9 @@ msgid "Unitary authority (wales)"
 msgstr "Autorité unitaire (pays de galles)"
 
 msgctxt "selection:country.subdivision,type:"
+msgid "Unknown"
+msgstr "Inconnu"
+
+msgctxt "selection:country.subdivision,type:"
 msgid "zone"
 msgstr "Zone"

--- a/scripts/import_countries.py
+++ b/scripts/import_countries.py
@@ -99,6 +99,8 @@ def update_subdivisions(countries, subdivisions):
     print("Update subdivisions", file=sys.stderr)
     Subdivision = Model.get('country.subdivision')
 
+    types = dict(Subdivision._fields['type']['selection'])
+    unknown_types = set()
     records = []
     for subdivision in _progress(pycountry.subdivisions):
         code = subdivision.code
@@ -108,7 +110,16 @@ def update_subdivisions(countries, subdivisions):
         else:
             record = Subdivision(code=code, country=countries[country_code])
         record.name = _remove_forbidden_chars(subdivision.name)
-        record.type = subdivision.type.lower()
+        type_ = subdivision.type.lower()
+        if type_ in types:
+            record.type = subdivision.type.lower()
+        else:
+            record.type = None
+            if type_ not in unknown_types:
+                print(
+                    "Unknown subdivision type: %s" % subdivision.type,
+                    file=sys.stderr)
+                unknown_types.add(type_)
         records.append(record)
 
     Subdivision.save(records)

--- a/scripts/import_countries.py
+++ b/scripts/import_countries.py
@@ -100,6 +100,8 @@ def update_subdivisions(countries, subdivisions):
     Subdivision = Model.get('country.subdivision')
 
     records = []
+    existing_subdiv_types = set(x[0] for x in
+        Subdivision._fields['type']['selection'])
     for subdivision in _progress(pycountry.subdivisions):
         code = subdivision.code
         country_code = subdivision.country_code
@@ -108,7 +110,9 @@ def update_subdivisions(countries, subdivisions):
         else:
             record = Subdivision(code=code, country=countries[country_code])
         record.name = _remove_forbidden_chars(subdivision.name)
-        record.type = subdivision.type.lower()
+        sub_type = subdivision.type.lower()
+        record.type = sub_type if sub_type in existing_subdiv_types \
+            else 'unknown'
         records.append(record)
 
     Subdivision.save(records)

--- a/scripts/import_countries.py
+++ b/scripts/import_countries.py
@@ -100,8 +100,6 @@ def update_subdivisions(countries, subdivisions):
     Subdivision = Model.get('country.subdivision')
 
     records = []
-    existing_subdiv_types = set(x[0] for x in
-        Subdivision._fields['type']['selection'])
     for subdivision in _progress(pycountry.subdivisions):
         code = subdivision.code
         country_code = subdivision.country_code
@@ -110,9 +108,7 @@ def update_subdivisions(countries, subdivisions):
         else:
             record = Subdivision(code=code, country=countries[country_code])
         record.name = _remove_forbidden_chars(subdivision.name)
-        sub_type = subdivision.type.lower()
-        record.type = sub_type if sub_type in existing_subdiv_types \
-            else 'unknown'
+        record.type = subdivision.type.lower()
         records.append(record)
 
     Subdivision.save(records)


### PR DESCRIPTION
Fix #0000

Imported subdivisions have unsupported types, blocking import_countries script. They will be set to None in this case.

Cherry-picked from https://github.com/tryton/country/commit/c830bf3a34681b6164bf495d4caca6c365f5ee67

Result after import:
![image](https://user-images.githubusercontent.com/15870843/158342410-31e45b00-9677-4b44-bc13-69edc74f208c.png)